### PR TITLE
Put the buffer-kill & tmpfile-delete inside unwind-protect

### DIFF
--- a/standardfmt.el
+++ b/standardfmt.el
@@ -89,10 +89,10 @@
                                           tmpfile))
               (message "Buffer is already semistandard")
             (standardfmt--apply-rcs-patch patchbuf)
-            (message "Applied semistandard"))))
+            (message "Applied semistandard")))
 
-    (kill-buffer patchbuf)
-    (delete-file tmpfile)))
+        (kill-buffer patchbuf)
+        (delete-file tmpfile))))
 
 (defun standardfmt--apply-rcs-patch (patch-buffer)
   "Apply an RCS-formatted diff from PATCH-BUFFER to the current buffer."


### PR DESCRIPTION
I noticed while using the auto-format-on-save functionality that tempfiles were accumulating in my `/tmp`. If I've understood the intentions in `(standardfmt)` correctly, the change in this PR fixes that. It ensures the `(unwind-protect)` kills the patch-buffer and deletes the tempfile at the end of *every* time the function is run, successfully or otherwise.